### PR TITLE
Metric silhouette markrobinsonuzh

### DIFF
--- a/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
+++ b/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
@@ -61,6 +61,7 @@ if (!is.na(opt$config)) {
 ## Code for calculating metric goes here
 ## --------------------------------------
 library(cluster)
+library(jsonlite)
 
 # # for testing - start
 label_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/SpaGCN/domains.tsv"

--- a/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
+++ b/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
@@ -1,0 +1,102 @@
+#!/usr/bin/env Rscript
+
+# Author_and_contribution: Niklas Mueller-Boetticher; created template
+# Author_and_contribution: Mark D. Robinson; coded the domain-specific F1
+
+suppressPackageStartupMessages(library(optparse))
+
+# TODO adjust description
+option_list <- list(
+  make_option(
+    c("-l", "--labels"),
+    type = "character", default = NULL,
+    help = "Labels from domain clustering."
+  ),
+  make_option(
+    c("-g", "--ground_truth"),
+    type = "character", default = NA,
+    help = "Groundtruth labels."
+  ),
+  make_option(
+    c("-e", "--embedding"),
+    type = "character", default = NA,
+    help = "Embedding of points in latent space. Potential usage for metrics without groundtruth."
+  ),
+  # format should be json
+  make_option(
+    c("-c", "--config"),
+    type = "character", default = NA,
+    help = "Optional config file (json) used to pass additional parameters."
+  ),
+  make_option(
+    c("-o", "--out_file"),
+    type = "character", default = NULL,
+    help = "Output file."
+  )
+)
+
+# TODO adjust description
+description <- "Calculate domain-specific F1 score (returns JSON with vector: F1 for each true domain)"
+
+opt_parser <- OptionParser(
+  usage = description,
+  option_list = option_list
+)
+opt <- parse_args(opt_parser)
+
+# Use these filepaths as input
+label_file <- opt$labels
+
+if (!is.na(opt$ground_truth)) {
+  groundtruth_file <- opt$ground_truth
+}
+if (!is.na(opt$embedding)) {
+  embedding_file <- opt$embedding
+}
+if (!is.na(opt$config)) {
+  config_file <- opt$config
+}
+
+
+## Code for calculating metric goes here
+## --------------------------------------
+library(cluster)
+
+# # for testing - start
+label_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/SpaGCN/domains.tsv"
+outfile <- "./cluster-specific-silhouette.json"
+embedding_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/log1p/hvg/pca_20/dimensionality_reduction.tsv"
+# groundtruth_file <- "data/libd_dlpfc/Br5595_151670/labels.tsv"
+# # for testing - stop
+
+domains <- read.delim(label_file, sep="\t", row.names = 1)
+embedding <- read.delim(embedding_file, sep="\t", row.names = 1)
+
+rn <- intersect(rownames(domains), rownames(embedding))
+
+# subset to common set
+embedding <- embedding[rn,,drop = FALSE]
+domains <- domains[rn,,drop = FALSE]
+
+# calculate silhouette score on the embeddings per cell
+sil <- silhouette(list(clustering=domains$label),
+                  dist=dist(embedding))
+
+agg_median <- aggregate(sil[,"sil_width",drop=FALSE], 
+                        list(cluster=sil[,"cluster"]), FUN = median)
+agg_mean <- aggregate(sil[,"sil_width",drop=FALSE], 
+                      list(cluster=sil[,"cluster"]), FUN = mean)
+
+(df <- data.frame(cluster = agg_mean$cluster,
+                  mean_sil_width = agg_mean$sil_width,
+                  median_sil_width = agg_median$sil_width))
+
+## Write output
+outfile <- file(opt$out_file)
+write_json(df,outfile)
+
+# from template
+# dir.create(dirname(outfile), showWarnings = FALSE, recursive = TRUE)
+# 
+# writeLines(format(metric, digits = 6, scientific = TRUE), outfile)
+# close(outfile)

--- a/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
+++ b/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
@@ -64,9 +64,9 @@ library(cluster)
 library(jsonlite)
 
 # # for testing - start
-label_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/SpaGCN/domains.tsv"
-outfile <- "./cluster-specific-silhouette.json"
-embedding_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/log1p/hvg/pca_20/dimensionality_reduction.tsv"
+# label_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/SpaGCN/domains.tsv"
+# outfile <- "./cluster-specific-silhouette.json"
+# embedding_file <- "~/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507/log1p/hvg/pca_20/dimensionality_reduction.tsv"
 # groundtruth_file <- "data/libd_dlpfc/Br5595_151670/labels.tsv"
 # # for testing - stop
 

--- a/metric/cluster-specific-silhouette/cluster-specific-silhouette.yml
+++ b/metric/cluster-specific-silhouette/cluster-specific-silhouette.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+dependencies:
+  - r-base=4.3.1
+  - r-optparse=1.7.3
+  - r-cluster=2.1.6
+  - r-jsonlite=1.8.7


### PR DESCRIPTION
OK, here I implemented a cluster-specific average silhouette width. The test script ran:

```
(base) jovyan@jupyter-markrobinsonuzh:~/scratch/SpaceHack2/test_scripts$ ./test_metric_cluster-specific-silhouette.sh 
Starting conda env: cluster-specific-silhouette
Making test_dir: /home/jovyan/test_metric (if necessary)
Running 'Rscript' for:
/home/jovyan/scratch/SpaceHack2/git_repo_clone/metric/cluster-specific-silhouette/cluster-specific-silhouette.r
Using arguments:
-l /home/jovyan/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507//SpaGCN/domains.tsv -o /home/jovyan/test_metric/cluster-specific-silhouette.json -e /home/jovyan/scratch/SpaceHack2/method_results/LIBD_DLPFC/Br5292_151507//log1p/hvg/pca_20/dimensionality_reduction.tsv
Warning message:
package ‘cluster’ was built under R version 4.3.2 
  cluster mean_sil_width median_sil_width
1       0    -0.03060313      -0.02656545
2       1     0.09863943       0.10967972
3       2    -0.07422993      -0.07258840
4       3    -0.05555974      -0.04435104
5       4     0.07101518       0.07841260
6       5    -0.11919100      -0.09575858
Checking output:
[{"cluster":0,"mean_sil_width":-0.0306,"median_sil_width":-0.0266},{"cluster":1,"mean_sil_width":0.0986,"median_sil_width":0.1097},{"cluster":2,"mean_sil_width":-0.0742,"median_sil_width":-0.0726},{"cluster":3,"mean_sil_width":-0.0556,"median_sil_width":-0.0444},{"cluster":4,"mean_sil_width":0.071,"median_sil_width":0.0784},{"cluster":5,"mean_sil_width":-0.1192,"median_sil_width":-0.0958}]
```
