### PR TITLE
method: RESEPT - env for deps only

### DIFF
--- a/method/RESEPT/environment.yml
+++ b/method/RESEPT/environment.yml
@@ -1,0 +1,41 @@
+name: RESEPT
+channels:
+  - conda-forge
+  - pytorch
+  - defaults
+dependencies:
+  # Python 3.6+ recommended in RESEPT docs
+  - python=3.8.*
+  - pip=23.*
+  - pytorch==1.5.1
+  - torchvision==0.6.1
+  - pip:
+    - anndata==0.7.6
+    - cityscapesscripts==2.2.0
+    - leidenalg==0.8.7
+    - matplotlib==3.3.4
+    # to make use of GPUs, "cpu" in the URL below should be replaced with one of
+    # "cu92", "cu101" or "cu102", depending on the CUDA version
+    - mmcv-full==1.3.0 -f https://download.openmmlab.com/mmcv/dist/cpu/torch1.5.0/index.html
+    - munkres==1.1.4
+    - networkx==2.5.1
+    - numba==0.53.1
+    - numpy==1.19.2
+    - opencv_contrib_python==4.5.1.48
+    - pandas==1.2.3
+    - pillow==8.3.1
+    - progress==1.6
+    - python_igraph==0.9.6
+    - requests==2.25.1
+    - rpy2==3.1.0
+    - scanpy==1.7.2
+    - scikit_image==0.18.1
+    - scikit-learn==0.24.2
+    - scipy==1.6.2
+    - seaborn==0.11.1
+    - six==1.15.0
+    - statsmodels==0.12.2
+    - terminaltables==3.1.0
+    - tqdm==4.60.0
+    - umap==0.1.1
+    - umap_learn==0.5.1


### PR DESCRIPTION
Partly addresses, but does not fix #14

- Provides Conda environment for all dependencies of method RESEPT
- The method itself must be separately deployed by cloning the [repository](https://github.com/OSU-BMBL/RESEPT/), as it is not packaged and therefore not included in the environment
- The PR does not include code to run the method
- For initial testing of the environment, function 1 of the [demo](https://github.com/OSU-BMBL/RESEPT/?tab=readme-ov-file#demo) provided by the method developers was partially ran on an 8-core x86_64 Intel i7-8650U CPU; no errors had occurred by the time it was manually terminated after ~45 min.
- **Important:** The Conda environment defined in this PR is configured to run on a CPU-only machine; to support GPUs, `environment.yml` has to be modified to set the appropriate CUDA version, as described in the environment file itself (untested)