### PR TITLE
Method PRECAST

### DIFF
--- a/method/precast/config/config_1.json
+++ b/method/precast/config/config_1.json
@@ -1,0 +1,1 @@
+{"use_neighbors": false}

--- a/method/precast/config/config_2.json
+++ b/method/precast/config/config_2.json
@@ -1,0 +1,1 @@
+{"use_neighbors": true}

--- a/method/precast/precast.yml
+++ b/method/precast/precast.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - r-base=4.3.1
   - r-optparse=1.7.3
+  - r-jsonlite=1.8.8
   - r-biocmanager=1.30.22
   - bioconductor-SingleCellExperiment=1.24.0
   - bioconductor-S4Vectors=0.40.2


### PR DESCRIPTION
Sven reported an issue that the dimensions of the provided neighbors did not match that of the data the method used.

To fix that, I subset the provided neighbors to the spots in the data used by the method after it computes neighbors by itself, which are then overwritten. 
I also added config files that determine whether the provided neighbors are used or not.