### PR TITLE
Update Banksy to bioc version + added configurations

### DIFF
--- a/method/BANKSY/banksy.yml
+++ b/method/BANKSY/banksy.yml
@@ -7,6 +7,16 @@ dependencies:
   - r-optparse=1.7.3
   - r-remotes=2.4.2
   - r-jsonlite=1.8.8
-  - r-biocmanager
+  - r-biocmanager=1.30.22
   - bioconductor-spatialexperiment=1.12.0
-  - leidenAlg=0.10.1
+  - bioconductor-scater=1.30.1
+  - r-leidenAlg=1.1.2
+  - r-aricode=1.0.3
+  - r-data.table=1.14.10
+  - r-dbscan=1.1.12
+  - r-irlba=2.3.5
+  - r-uwot=0.1.16
+  - r::r-rcpphungarian=0.3
+  - numpy=1.26.3
+  - r-mclust=6.0.1
+  - r-igraph=1.5.1

--- a/method/BANKSY/banksy_env.sh
+++ b/method/BANKSY/banksy_env.sh
@@ -7,7 +7,7 @@ conda env create -f banksy.yml
 conda activate banksy_env
 
 # Install the required R packages
-Rscript -e "remotes::install_github('prabhakarlab/Banksy', dependencies = TRUE, ref = 'b1a2c8bb2af06346f303637b9bba18faa1a1fe32')"
+Rscript -e "remotes::install_github('prabhakarlab/Banksy', dependencies = FALSE, ref = 'beee50c14cf44eeac0c805619614e209458014ef')"
 
 
 

--- a/method/BANKSY/config/config_2.json
+++ b/method/BANKSY/config/config_2.json
@@ -1,0 +1,1 @@
+{"method": "leiden", "lambda": 0.8, "k_geom": 50, "npcs": 50, "resolution": 1.0}

--- a/method/BANKSY/config/config_3.json
+++ b/method/BANKSY/config/config_3.json
@@ -1,0 +1,1 @@
+{"method": "leiden", "lambda": 1, "k_geom": 50, "npcs": 50, "resolution": 0.8}

--- a/method/BANKSY/config/config_4.json
+++ b/method/BANKSY/config/config_4.json
@@ -1,0 +1,1 @@
+{"method": "leiden", "lambda": 0.8, "k_geom": 50, "npcs": 50, "resolution": 1.2}

--- a/method/BANKSY/config/config_5.json
+++ b/method/BANKSY/config/config_5.json
@@ -1,0 +1,1 @@
+{"method": "leiden", "lambda": 1.0, "k_geom": 50, "npcs": 50, "resolution": 1.0}

--- a/method/BANKSY/config/config_6.json
+++ b/method/BANKSY/config/config_6.json
@@ -1,0 +1,1 @@
+{"method": "louvain", "lambda": 0.8, "k_geom": 50, "npcs": 50, "resolution": 0.8}

--- a/method/BANKSY/config/config_7.json
+++ b/method/BANKSY/config/config_7.json
@@ -1,0 +1,1 @@
+{"method": "kmeans", "lambda": 0.8, "k_geom": 50, "npcs": 50, "resolution": 0.8}

--- a/method/BANKSY/config/config_8.json
+++ b/method/BANKSY/config/config_8.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "lambda": 0.8, "k_geom": 50, "npcs": 50, "resolution": 0.8}


### PR DESCRIPTION
Resolves Issue #172

I still had to install it from GitHub because the Bioc (devel) release requires R4.4, which has not been released yet.
Setting `dependencies=FALSE` reduced installation time tremendously. Instead, I had to add some packages to the yaml, which also meant I could pin their versions.