### PR TITLE
Update xenium-mouse-brain-SergioSalas.py

### DIFF
--- a/data/xenium-mouse-brain-SergioSalas/xenium-mouse-brain-SergioSalas.py
+++ b/data/xenium-mouse-brain-SergioSalas/xenium-mouse-brain-SergioSalas.py
@@ -85,7 +85,8 @@ def convert_data(out_dir):
             df_coordinates_tsv.to_csv(sample_output_folder/'coordinates.tsv',sep="\t",index_label="")
         
             # Matrix
-            scipy.io.mmwrite(f"{sample_output_folder}/counts.mtx",adata.X)
+            scipy.io.mmwrite(f"{sample_output_folder}/counts.mtx",scipy.sparse.coo_matrix(adata.X))  # MR: use sparse version
+            #scipy.io.mmwrite(f"{sample_output_folder}/counts.mtx",adata.X)
     
             print(f'{sample} ready.')
     


### PR DESCRIPTION
- getting the code to write the sparse version of the MM file, as R seems to like this.
- my test was done like this in R (using old `counts.mtx` and new one):
```
> library(Matrix)
> f1 <- "data_out/region_main/counts.mtx"
> x <- readMM(f1)
Error in scan(file, nmax = 1, what = what, quiet = TRUE, ...) : 
  scan() expected 'an integer', got '4.97832394e+00'
> f2 <- "sparse-data_out/region_main/counts.mtx"
> y <- readMM(f2)
> y[1:10,1:10]
10 x 10 sparse Matrix of class "dgTMatrix"
                                                     
 [1,] 4.978324 3.893389 . . . 3.893389 . . .        .
 [2,] .        3.631375 . . . .        . . .        .
 [3,] 4.476843 .        . . . 3.400714 . . .        .
 [4,] 4.394449 5.993961 . . . .        . . 4.394449 .
 [5,] 5.674139 .        . . . 3.310004 . . 3.310004 .
 [6,] 5.245335 6.158457 . . . .        . . .        .
 [7,] 5.783476 .        . . . .        . . .        .
 [8,] 5.672825 .        . . . 5.386289 . . .        .
 [9,] 5.732345 .        . . . .        . . .        .
[10,] 4.571549 .        . . . .        . . 3.888691 .
```