### PR TITLE
Config for optional methods arguments

### DIFF
--- a/templates/method_optargs.json
+++ b/templates/method_optargs.json
@@ -1,0 +1,7 @@
+{
+    "matrix": "counts",
+    "integrated_feature_selection": false,
+    "image": true,
+    "neighbors": false,
+    "config_file": true
+}

--- a/templates/method_optargs.schema.yaml
+++ b/templates/method_optargs.schema.yaml
@@ -1,0 +1,30 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+
+description: Which (optional) parameters can the method use
+type: object
+properties:
+
+    matrix: 
+        description: What input does the method take
+        type: string
+        enum:
+            - counts
+            - transform
+            - dimensionality_reduction
+            # - counts_or_transform
+
+    integrated_feature_selection:
+        description: Does the method include feature selection? I.e. do not pass pre-selected features.
+        type: boolean
+        
+    image:
+        description: Can the method use H&E images?
+        type: boolean
+        
+    neighbors:
+        description: Can the method use existing neighbor definitions?
+        type: boolean
+
+    config_file:
+        description: Does the method take an additional config file?
+        type: boolean


### PR DESCRIPTION
To be able to pass e.g. raw counts to some methods and processed counts to others we need to define a configuration for each method.

This will also avoid running methods multiple times on the same input thus generating duplicate results:
Consider a method that e.g. does not use the input from feature-selection. If we run it with feature-selected data and we have multiple strategies for feature selection the method will be run multiple times but should always generate the same result. This can be avoided by defining which optional arguments are used by a method.

This PR adds a template for what the config could look like as well as a schema file to define valid values/be able to validate the config files.