### PR TITLE
Add metric optargs

### DIFF
--- a/metric/ARI/ARI_optargs.json
+++ b/metric/ARI/ARI_optargs.json
@@ -1,0 +1,5 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}

--- a/metric/CHAOS/CHAOS_optargs.json
+++ b/metric/CHAOS/CHAOS_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": false,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/Calinski-Harabasz/Calinski-Harabasz_optargs.json
+++ b/metric/Calinski-Harabasz/Calinski-Harabasz_optargs.json
@@ -1,0 +1,5 @@
+{
+    "groundtruth": false,
+    "embedding": true,
+    "config_file": false
+}

--- a/metric/Completeness/Completeness_optargs.json
+++ b/metric/Completeness/Completeness_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/Davies-Bouldin/Davies-Bouldin_optargs.json
+++ b/metric/Davies-Bouldin/Davies-Bouldin_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": false,
+    "embedding": true,
+    "config_file": false
+}
+

--- a/metric/Entropy/Entropy_optargs.json
+++ b/metric/Entropy/Entropy_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/FMI/FMI_optargs.json
+++ b/metric/FMI/FMI_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/Homogeneity/Homogeneity_optargs.json
+++ b/metric/Homogeneity/Homogeneity_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/LISI/LISI_optargs.json
+++ b/metric/LISI/LISI_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": true,
+    "config_file": true
+}
+

--- a/metric/MCC/MCC_optargs.json
+++ b/metric/MCC/MCC_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/NMI/NMI_optargs.json
+++ b/metric/NMI/NMI_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/PAS/PAS_optargs.json
+++ b/metric/PAS/PAS_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": false,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/V_measure/V_measure_optargs.json
+++ b/metric/V_measure/V_measure_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": true
+}
+

--- a/metric/cluster-specific-silhouette/cluster-specific-silhouette_optargs.json
+++ b/metric/cluster-specific-silhouette/cluster-specific-silhouette_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": false,
+    "embedding": true,
+    "config_file": false
+}
+

--- a/metric/domain-specific-f1/domain-specific-f1_optargs.json
+++ b/metric/domain-specific-f1/domain-specific-f1_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+

--- a/metric/jaccard/jaccard_optargs.json
+++ b/metric/jaccard/jaccard_optargs.json
@@ -1,0 +1,6 @@
+{
+    "groundtruth": true,
+    "embedding": false,
+    "config_file": false
+}
+


### PR DESCRIPTION
PAS and CHAOS require **spatial coordinates** as input. It doesn't fit into our current system but maybe we can find a workaround via a `config` file (to be discussed).

Fixed the messy git commit (sorry for the mess before!). I've double-checked the requirements on both scripts and the [metadata sheet](https://docs.google.com/spreadsheets/d/1QCeAF4yQG4bhZSGPQwwVBj_XF7ADY_2mK5xivAIfHsc/edit?usp=sharing) but in case you think some config is wrong please lmk. 