### PR TITLE
PAS and CHAOS metric optargs

### DIFF
--- a/metric/CHAOS/CHAOS_optargs.json
+++ b/metric/CHAOS/CHAOS_optargs.json
@@ -1,6 +1,7 @@
 {
     "groundtruth": false,
     "embedding": false,
-    "config_file": false
+    "config_file": false,
+    "physical_coordinate": true
 }
 

--- a/metric/PAS/PAS_optargs.json
+++ b/metric/PAS/PAS_optargs.json
@@ -1,6 +1,7 @@
 {
     "groundtruth": false,
     "embedding": false,
-    "config_file": false
+    "config_file": false,
+    "physical_coordinate": true
 }
 

--- a/templates/metric_optargs.schema.yaml
+++ b/templates/metric_optargs.schema.yaml
@@ -13,5 +13,10 @@ properties:
         type: boolean
 
     config_file:
-        description: Does the method take an additional config file?
+        description: Does the metric take an additional config file?
+        type: boolean
+
+    # Optional, only added when your metric requires this
+    physical_coordinate:
+        description: Does the metric take physcial coordination of the sample?
         type: boolean

--- a/templates/metric_optargs.schema.yaml
+++ b/templates/metric_optargs.schema.yaml
@@ -16,7 +16,7 @@ properties:
         description: Does the metric take an additional config file?
         type: boolean
 
-    # Optional, only added when your metric requires this
+    # Optional, only add when your metric requires this
     physical_coordinate:
         description: Does the metric take physcial coordination of the sample?
         type: boolean


### PR DESCRIPTION
PAS and CHAOS require physical coordinate as input. I modify their optargs to achieve the following:

1. adding options "physical_coordinate" in their optargs. Snakemake will check first if key "physical_coordiante" exists in the optargs file, then check if it's true. Tested in `wip_wf_optargs` branch and functional.

2. Change metrics optargs schema file to notify future implementers about this option.