### PR TITLE
Adding dummy count matrix for seurat and maple

### DIFF
--- a/method/maple/maple.r
+++ b/method/maple/maple.r
@@ -161,13 +161,23 @@ get_SpatialExperiment <- function(
 seed <- opt$seed
 set.seed(seed)
 # TODO if the method requires the seed elsewhere please pass it on
+
+if (!exists("matrix_file")) {
+    matrix_file <- NA
+}
+
 # You can use the data as SpatialExperiment
 spe <- get_SpatialExperiment(feature_file = feature_file,observation_file = observation_file,
                                     coord_file = coord_file, reducedDim_file = dimred_file, matrix_file = matrix_file)
 
+# Create a dummy matrix for seurat object requirement
+if (is.null(assayNames(spe))){
+    assay(spe, "counts", withDimnames = FALSE) <- Matrix::Matrix(0, nrow=nrow(spe), ncol=ncol(spe), sparse=TRUE)
+}
+
 ## Your code goes here
 # TODO
-seurat_obj <- as.Seurat(spe)
+seurat_obj <- as.Seurat(spe, data=NULL)
 
 # Insert image coordinates
 seurat_obj@images$image =  new(

--- a/method/seurat/seurat.r
+++ b/method/seurat/seurat.r
@@ -174,8 +174,14 @@ spe <- get_SpatialExperiment(
     reducedDim_file = dimred_file
 )
 
+# Create a dummy matrix for seurat object requirement
+if (is.null(assayNames(spe))){
+    assay(spe, "counts", withDimnames = FALSE) <- Matrix::Matrix(0, nrow=nrow(spe), ncol=ncol(spe), sparse=TRUE)
+}
+
+
 # Convert to Seurat object
-seurat_obj <- as.Seurat(spe)
+seurat_obj <- as.Seurat(spe, data=NULL)
 
 # Find neighbors
 seurat_obj <- FindNeighbors(seurat_obj, dims = 1:ndims)
@@ -189,7 +195,8 @@ tunek <- function(seurat_obj, k){
         resolution = r,
         algorithm = algorithm,
         method = method,
-        random.seed = seed)
+        random.seed = seed,
+        verbose = FALSE)
     if(length(unique(Idents(seu))) >= k) break
   }
   return(seu)


### PR DESCRIPTION
Both methods have 2 things in common:
1. They both require seurat object to process, which means they all need a line 
```
seurat_obj <- as.Seurat(spe)
```
2. They both only require `dimensional_reduction` object only, so `spe` doesn't have a count matrix.

This leads to an error: for `as.Seurat` to work, the `spe` object must have at least a `count` slot. Since this count matrix is not used in the later processing. I added those commits to create a dummy count matrix to fill in the space. All these changes are tested in the pipeline and are working.

Additionally, I also set seurat verbose to FALSE so it doesn't take up the whole screen when running snakemake.

---

**TODO**: Can you check if Maple for sure does not need count matrix if we stick to `emb = "PCs"`? Maybe @gmoranzoni can confirm?