### PR TITLE
Add package for specific functions

### DIFF
--- a/method/BANKSY/banksy.r
+++ b/method/BANKSY/banksy.r
@@ -172,8 +172,8 @@ assay_name <- "normcounts"
 set.seed(seed)
 
 # Normalization to mean library size
-spe <- computeLibraryFactors(spe)
-assay(spe, assay_name) <- normalizeCounts(spe, log = FALSE)
+spe <- scuttle::computeLibraryFactors(spe)
+assay(spe, assay_name) <- scuttle::normalizeCounts(spe, log = FALSE)
 
 # Run BANKSY
 spe <- Banksy::computeBanksy(spe, assay_name = assay_name, k_geom = k_geom)

--- a/method/BANKSY/banksy.yml
+++ b/method/BANKSY/banksy.yml
@@ -10,6 +10,7 @@ dependencies:
   - r-biocmanager=1.30.22
   - bioconductor-spatialexperiment=1.12.0
   - bioconductor-scater=1.30.1
+  - bioconductor-scuttle=1.12.0
   - r-leidenAlg=1.1.2
   - r-aricode=1.0.3
   - r-data.table=1.14.10


### PR DESCRIPTION
Hi, in BANKSY workflow there're some functions from package `scuttle`. Yet in the BANKSY script, `scuttle` is not explicitly loaded, leading to a function-not-found error when running the script in the pipeline. I added `scuttle::` for those functions so the script can work properly.

This is working now. Do I need to add `library(scuttle)` at the beginning of the script?