### PR TITLE
Change BayesSpace opts

### DIFF
--- a/method/BayesSpace/BayesSpace.r
+++ b/method/BayesSpace/BayesSpace.r
@@ -27,7 +27,7 @@ option_list <- list(
   ),
   make_option(
     c("-n", "--neighbors"),
-    type = "character", default = NULL,
+    type = "character", default = NA,
     help = "Path to neighbor definitions. Square matrix (not necessarily symmetric) where each row contains the neighbors of this observation (as mtx)."
   ),
   make_option(


### PR DESCRIPTION
BayesSpace set neighbors default to NULL, while at line 90 it checked `is.na`, this leads to an error, change the defeault to `NA` to solve this issue. In the R method template, neighbors are also set to `NA` instead of `NULL`.

https://github.com/SpatialHackathon/SpaceHack2023/blob/b31d1256b27ba8e0c6735222c87fdf39171f04e2/method/BayesSpace/BayesSpace.r#L90-L92