### PR TITLE
Update dataset gdown version

### DIFF
--- a/data/xenium-mouse-brain-SergioSalas/environment.yml
+++ b/data/xenium-mouse-brain-SergioSalas/environment.yml
@@ -2,6 +2,6 @@ channels:
   - conda-forge
 dependencies:
   - anndata=0.10.3
-  - gdown=4.7.1
+  - gdown=4.6.0
   - scipy=1.11.4
   - pandas=2.1.4


### PR DESCRIPTION
xenium-mouse-brainSergioSalas dataset is hosted in google drive. With the previous version of gdown, it has some problems downloading datasets from even public google drive folders (check the issue [here](https://github.com/wkentaro/gdown/issues/43)). Fixed it by changing the gdown version. 