### PR TITLE
Native GraphST

### DIFF
--- a/method/GraphST/config/config_1.json
+++ b/method/GraphST/config/config_1.json
@@ -1,1 +1,1 @@
-{"method": "louvain", "refine": false}
+{"method": "leiden", "refine": true, "radius": 100, "n_pcs": 20, "n_genes": 3000}

--- a/method/GraphST/config/config_2.json
+++ b/method/GraphST/config/config_2.json
@@ -1,1 +1,1 @@
-{"method": "leiden", "refine": false}
+{"method": "leiden", "refine": false, "radius": 50, "n_pcs": 20, "n_genes": 3000}

--- a/method/GraphST/config/config_3.json
+++ b/method/GraphST/config/config_3.json
@@ -1,1 +1,1 @@
-{"method": "mclust", "refine": false}
+{"method": "leiden", "refine": true, "radius": 50, "n_pcs": 20, "n_genes": 3000}

--- a/method/GraphST/config/config_4.json
+++ b/method/GraphST/config/config_4.json
@@ -1,1 +1,1 @@
-{"method": "louvain", "refine": true, "radius": 100}
+{"method": "mclust", "refine": true, "radius": 100, "n_pcs": 20, "n_genes": 3000}

--- a/method/GraphST/config/config_5.json
+++ b/method/GraphST/config/config_5.json
@@ -1,1 +1,0 @@
-{"method": "leiden", "refine": true, "radius": 100}

--- a/method/GraphST/config/config_6.json
+++ b/method/GraphST/config/config_6.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "refine": true, "radius": 100}

--- a/method/GraphST/config/config_7.json
+++ b/method/GraphST/config/config_7.json
@@ -1,2 +1,0 @@
-
-{"method": "mclust", "refine": true, "radius": 50}

--- a/method/GraphST/config/config_8.json
+++ b/method/GraphST/config/config_8.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "refine": true, "radius": 50}

--- a/method/GraphST/config/config_9.json
+++ b/method/GraphST/config/config_9.json
@@ -1,1 +1,0 @@
-{"method": "leiden", "refine": true, "radius": 50}

--- a/method/GraphST/config/config_default.json
+++ b/method/GraphST/config/config_default.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "refine": false, "radius": 50, "n_pcs": 20, "n_genes": 3000, "source": "https://github.com/JinmiaoChenLab/GraphST/blob/main/GraphST/preprocess.py#L99", "source2": "https://github.com/JinmiaoChenLab/GraphST/blob/main/GraphST/utils.py#L33#L64"}

--- a/method/GraphST/config/config_dlpfc.json
+++ b/method/GraphST/config/config_dlpfc.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "refine": true, "radius": 50, "n_pcs": 20, "n_genes": 3000, "source": "https://deepst-tutorials.readthedocs.io/en/latest/Tutorial%201_10X%20Visium.html#Spatial-clustering-and-refinement"}


### PR DESCRIPTION
Native implementation for GraphST and updated configurations

- Removed all configurations containing 'louvain', keeping only 'leiden' and 'mclust'.
- The vignettes have the same parameter settings for dlpfc and stereo-seq data (only the 'datatype' needs to be specified, which is replaced by 'technology' in our case). Thus, I kept only one configuration from the vignette.