### PR TITLE
Native STAGATE

### DIFF
--- a/method/STAGATE/config/config_1.json
+++ b/method/STAGATE/config/config_1.json
@@ -1,1 +1,1 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "res": 0.5}
+{"method": "louvain", "model": "Radius", "rad_cutoff": 150, "n_genes": 3000, "min_cells": 0}

--- a/method/STAGATE/config/config_10.json
+++ b/method/STAGATE/config/config_10.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "model": "KNN", "k_cutoff": 10, "res": 0.5}

--- a/method/STAGATE/config/config_11.json
+++ b/method/STAGATE/config/config_11.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "model": "KNN", "k_cutoff": 15, "res": 0.5}

--- a/method/STAGATE/config/config_12.json
+++ b/method/STAGATE/config/config_12.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "KNN", "k_cutoff": 10, "res": 0.5}

--- a/method/STAGATE/config/config_13.json
+++ b/method/STAGATE/config/config_13.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "KNN", "k_cutoff": 15, "res": 0.5}

--- a/method/STAGATE/config/config_14.json
+++ b/method/STAGATE/config/config_14.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "model": "KNN", "k_cutoff": 10, "res": 1}

--- a/method/STAGATE/config/config_15.json
+++ b/method/STAGATE/config/config_15.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "model": "KNN", "k_cutoff": 15, "res": 1.5}

--- a/method/STAGATE/config/config_16.json
+++ b/method/STAGATE/config/config_16.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "KNN", "k_cutoff": 10, "res": 0.5}

--- a/method/STAGATE/config/config_17.json
+++ b/method/STAGATE/config/config_17.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "KNN", "k_cutoff": 10, "res": 1}

--- a/method/STAGATE/config/config_18.json
+++ b/method/STAGATE/config/config_18.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "KNN", "k_cutoff": 10, "res": 1.5}

--- a/method/STAGATE/config/config_2.json
+++ b/method/STAGATE/config/config_2.json
@@ -1,1 +1,1 @@
-{"method": "louvain", "model": "Radius", "rad_cutoff": 300, "res": 0.5}
+{"method": "louvain", "model": "KNN", "k_cutoff": 10, "n_genes": 3000, "min_cells": 0}

--- a/method/STAGATE/config/config_3.json
+++ b/method/STAGATE/config/config_3.json
@@ -1,1 +1,1 @@
-{"method": "louvain", "model": "Radius", "rad_cutoff": 150, "res": 0.5}
+{"method": "louvain", "model": "KNN", "k_cutoff": 15, "n_genes": 3000, "min_cells": 0}

--- a/method/STAGATE/config/config_4.json
+++ b/method/STAGATE/config/config_4.json
@@ -1,1 +1,1 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 300, "res": 0.5}
+{"method": "mclust", "model": "KNN", "k_cutoff": 10, "n_genes": 3000, "min_cells": 0}

--- a/method/STAGATE/config/config_5.json
+++ b/method/STAGATE/config/config_5.json
@@ -1,1 +1,1 @@
-{"method": "louvain", "model": "Radius", "rad_cutoff": 150, "res": 1}
+{"method": "mclust", "model": "KNN", "k_cutoff": 15, "n_genes": 3000, "min_cells": 0}

--- a/method/STAGATE/config/config_6.json
+++ b/method/STAGATE/config/config_6.json
@@ -1,1 +1,0 @@
-{"method": "louvain", "model": "Radius", "rad_cutoff": 150, "res": 1.5}

--- a/method/STAGATE/config/config_7.json
+++ b/method/STAGATE/config/config_7.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "res": 1}

--- a/method/STAGATE/config/config_8.json
+++ b/method/STAGATE/config/config_8.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "res": 1.5}

--- a/method/STAGATE/config/config_9.json
+++ b/method/STAGATE/config/config_9.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 300, "res": 0.5}

--- a/method/STAGATE/config/config_default.json
+++ b/method/STAGATE/config/config_default.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "n_genes": 3000, "min_cells": 0, "source": "https://stagate.readthedocs.io/en/latest/T1_DLPFC.html"}

--- a/method/STAGATE/config/config_dlpfc.json
+++ b/method/STAGATE/config/config_dlpfc.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "n_genes": 3000, "min_cells": 0, "source": "https://stagate.readthedocs.io/en/latest/T1_DLPFC.html"}

--- a/method/STAGATE/config/config_dlpfc.json
+++ b/method/STAGATE/config/config_dlpfc.json
@@ -1,1 +1,0 @@
-{"method": "mclust", "model": "Radius", "rad_cutoff": 150, "n_genes": 3000, "min_cells": 0, "source": "https://stagate.readthedocs.io/en/latest/T1_DLPFC.html"}

--- a/method/STAGATE/config/config_slide_stereo.json
+++ b/method/STAGATE/config/config_slide_stereo.json
@@ -1,0 +1,1 @@
+{"method": "louvain", "model": "Radius", "rad_cutoff": 50, "n_genes": 3000, "min_cells": 50, "source": "https://stagate.readthedocs.io/en/latest/T3_Slide-seqV2.html", "source2": "https://stagate.readthedocs.io/en/latest/T4_Stereo.html"}

--- a/method/STAGATE/config/config_starmap.json
+++ b/method/STAGATE/config/config_starmap.json
@@ -1,0 +1,1 @@
+{"method": "mclust", "model": "Radius", "rad_cutoff": 400, "n_genes": 3000, "min_cells": 0, "source": "https://stagate.readthedocs.io/en/latest/T9_STARmap.html"}


### PR DESCRIPTION
- Added a filter to follow the vignettes.
- Updated configurations; removed the unused resolution parameter 'res'.
- Did not use `n_pcs` because STAGATE doesn't use PCAs when alpha=0, which is the default setting and is also used in all tutorials. (source: https://github.com/QIFEIDKN/STAGATE/blob/main/STAGATE/Train_STAGATE.py#R85).
- We might consider implementing STAGATE based on the PyG framework later (as it is "more than 10 times faster than the STAGATE based on the TensorFlow 1 framework").