### PR TITLE
Native stardust

### DIFF
--- a/method/stardust/config/config_1.json
+++ b/method/stardust/config/config_1.json
@@ -1,4 +1,5 @@
 {
   "method": "auto",
-  "npcs": 10
+  "npcs": 20,
+  "Config_rationale": "Change the npcs from 10 to 20"
 }

--- a/method/stardust/config/config_1.json
+++ b/method/stardust/config/config_1.json
@@ -1,5 +1,0 @@
-{
-  "method": "auto",
-  "npcs": 20,
-  "Config_rationale": "Change the npcs from 10 to 20"
-}

--- a/method/stardust/config/config_2.json
+++ b/method/stardust/config/config_2.json
@@ -1,6 +1,0 @@
-{
-  "method": "weight",
-  "npcs": 20,
-  "weight": 0.75,
-  "Config_rationale": "Change the npcs from 10 to 20"
-}

--- a/method/stardust/config/config_2.json
+++ b/method/stardust/config/config_2.json
@@ -1,5 +1,6 @@
 {
   "method": "weight",
-  "npcs": 10,
-  "weight": 0.75
+  "npcs": 20,
+  "weight": 0.75,
+  "Config_rationale": "Change the npcs from 10 to 20"
 }

--- a/method/stardust/config/config_3.json
+++ b/method/stardust/config/config_3.json
@@ -1,4 +1,0 @@
-{
-  "method": "auto",
-  "npcs": 20
-}

--- a/method/stardust/config/config_4.json
+++ b/method/stardust/config/config_4.json
@@ -1,5 +1,0 @@
-{
-  "method": "weight",
-  "npcs": 20,
-  "weight": 0.75
-}

--- a/method/stardust/config/config_default.json
+++ b/method/stardust/config/config_default.json
@@ -1,5 +1,6 @@
 {
   "method": "auto",
   "npcs": 10,
-  "reference": "https://github.com/InfOmics/stardust/blob/master/R/autoStardust.R"
+  "n_genes": 3000,
+  "source": "https://github.com/InfOmics/stardust/blob/master/R/autoStardust.R"
 }

--- a/method/stardust/config/config_default.json
+++ b/method/stardust/config/config_default.json
@@ -1,0 +1,5 @@
+{
+  "method": "auto",
+  "npcs": 10,
+  "reference": "https://github.com/InfOmics/stardust/blob/master/R/autoStardust.R"
+}

--- a/method/stardust/config/config_tutorial.json
+++ b/method/stardust/config/config_tutorial.json
@@ -1,0 +1,6 @@
+{
+  "method": "weight",
+  "npcs": 10,
+  "weight": 0.75,
+  "reference":"https://github.com/InfOmics/stardust/blob/master/README.md"
+}

--- a/method/stardust/config/config_tutorial.json
+++ b/method/stardust/config/config_tutorial.json
@@ -1,6 +1,7 @@
 {
   "method": "weight",
   "npcs": 10,
+  "n_genes": 3000,
   "weight": 0.75,
-  "reference":"https://github.com/InfOmics/stardust/blob/master/README.md"
+  "source":"https://github.com/InfOmics/stardust/blob/master/README.md"
 }


### PR DESCRIPTION
So added stardust implementation of different configs...

I also changed the script a bit. I do this to avoid repeated computation when screening for resolution parameters. 

In our previous script, the resolution screening requires running the `autostardust` or `weightedstardust` function over and over again. This function is basically a wrapper for an entire Seurat pipeline. So running them again results in a repeated calculations of `scTranscform` and `createSeuratobjects` etc. I broke the wrapper down and now the resolution screening only requires screening of the last step.