### PR TITLE
Data: QC parameters update

### DIFF
--- a/data/SEA_AD_data/SEA_AD_data_optargs.json
+++ b/data/SEA_AD_data/SEA_AD_data_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/STARmap-2018-mouse-cortex/STARmap-2018-mouse-cortex_optargs.json
+++ b/data/STARmap-2018-mouse-cortex/STARmap-2018-mouse-cortex_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/libd_dlpfc/libd_dlpfc_optargs.json
+++ b/data/libd_dlpfc/libd_dlpfc_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 100,
-    "min_genes" : 200,
-    "min_counts": 200
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/mouse_brain_sagittal_anterior/mouse_brain_sagittal_anterior_optargs.json
+++ b/data/mouse_brain_sagittal_anterior/mouse_brain_sagittal_anterior_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/mouse_brain_sagittal_posterior/mouse_brain_sagittal_posterior_optargs.json
+++ b/data/mouse_brain_sagittal_posterior/mouse_brain_sagittal_posterior_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/mouse_kidney_coronal/mouse_kidney_coronal_optargs.json
+++ b/data/mouse_kidney_coronal/mouse_kidney_coronal_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/osmfish_Ssp/osmfish_Ssp_optargs.json
+++ b/data/osmfish_Ssp/osmfish_Ssp_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/sotip_simulation/sotip_simulation_optargs.json
+++ b/data/sotip_simulation/sotip_simulation_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/spatialDLPFC/spatialDLPFC_optargs.json
+++ b/data/spatialDLPFC/spatialDLPFC_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/visium_breast_cancer_SEDR/visium_breast_cancer_SEDR_optargs.json
+++ b/data/visium_breast_cancer_SEDR/visium_breast_cancer_SEDR_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/visium_chicken_heart/chicken_heart_optargs.json
+++ b/data/visium_chicken_heart/chicken_heart_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/xenium-breast-cancer/xenium-breast-cancer_optargs.json
+++ b/data/xenium-breast-cancer/xenium-breast-cancer_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 

--- a/data/xenium-mouse-brain-SergioSalas/xenium-mouse-brain-SergioSalas_optargs.json
+++ b/data/xenium-mouse-brain-SergioSalas/xenium-mouse-brain-SergioSalas_optargs.json
@@ -1,6 +1,6 @@
 {
-    "min_cells" : 0,
-    "min_genes" : 0,
-    "min_counts": 0
+    "min_cells" : 1,
+    "min_genes" : 1,
+    "min_counts": 1
 }
 


### PR DESCRIPTION
Hi :))

The workflow has a QC step that requires an optional `optargs.json` file for each dataset implemented. The previous threshold parameters were selected quite intuitively and based on some online books. Maybe it's best if we refactorize all the parameters to 1 and only edit the threshold when needed.

The optargs file is optional. I will push a PR later to make the workflow functional for datasets that don't have an optargs file. :))