### PR TITLE
Native SOTIP

### DIFF
--- a/method/SOTIP/config/config.json
+++ b/method/SOTIP/config/config.json
@@ -1,1 +1,0 @@
-{"knn": 10, "n_neighbours": 500}

--- a/method/SOTIP/config/config_MIBI_TNBC.json
+++ b/method/SOTIP/config/config_MIBI_TNBC.json
@@ -1,0 +1,5 @@
+{
+    "res": 1,
+    "n_neighbours": 800,
+    "source": "https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/tutorial/scMEP_CLCC.ipynb"
+}

--- a/method/SOTIP/config/config_Visium_dlpfc.json
+++ b/method/SOTIP/config/config_Visium_dlpfc.json
@@ -1,0 +1,6 @@
+{
+    "n_pcs": 100,
+    "res": 2,
+    "n_neighbours": 200,
+    "source": "https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/Visium_Cortex/SDM_Visium_cortex.ipynb"
+}

--- a/method/SOTIP/config/config_default.json
+++ b/method/SOTIP/config/config_default.json
@@ -1,0 +1,5 @@
+{
+    "res": 1,
+    "n_neighbours": 15,
+    "source": "https://scanpy.readthedocs.io/en/stable/api/index.html"
+}

--- a/method/SOTIP/config/config_osmFISH.json
+++ b/method/SOTIP/config/config_osmFISH.json
@@ -1,0 +1,4 @@
+{
+    "n_neighbours": 500,
+    "source": "https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/tutorial/osmFISH_cortex.ipynb"
+}

--- a/method/SOTIP/config/config_scMEP_CLCC.json
+++ b/method/SOTIP/config/config_scMEP_CLCC.json
@@ -1,0 +1,5 @@
+{
+    "res": 1,
+    "n_neighbours": 100,
+    "source": "https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/tutorial/scMEP_CLCC.ipynb"
+}

--- a/method/SOTIP/sotip_optargs.json
+++ b/method/SOTIP/sotip_optargs.json
@@ -1,5 +1,5 @@
 {
-    "matrix": "dimensionality_reduction",
+    "matrix": "counts",
     "integrated_feature_selection": false,
     "image": false,
     "neighbors": false,


### PR DESCRIPTION
- Regarding `config["res"]`:  In their tutorials ([tutorial1](https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/tutorial/Visium_Cortex.ipynb) and [tutorial2](https://github.com/TencentAILabHealthcare/SOTIP/blob/master/SOTIP_analysis/tutorial/osmFISH_cortex.ipynb)), they either **over-clustered** and then **merged** clusters to achieve the target number or **searched for a resolution** initially. So, I added the resolution parameter to the config. 
While testing, even if the initial resolution matches the expected clusters, we might still end up with more clusters. Hence, I included merging steps for both scenarios.

- As all SOTIP spatial domain detection pipelines don't use any feature selection function, I didn't add `n_genes`. 