### PR TITLE
Native scanit

### DIFF
--- a/method/SCAN-IT/config.json
+++ b/method/SCAN-IT/config.json
@@ -1,1 +1,0 @@
-{"n_neighbours": 15, "res": 0.5}

--- a/method/SCAN-IT/config/config_default.json
+++ b/method/SCAN-IT/config/config_default.json
@@ -1,0 +1,10 @@
+{
+    "n_genes": 3000,
+    "SomNode_k": 20,
+    "knn_n_neighbours": 10,
+    "n_h": 32,
+    "n_epoch": 1000,
+    "alpha_n_layers": 1,
+    "n_neighbours": 15, 
+    "source": "https://github.com/zcang/SCAN-IT/blob/main/scanit/tools/_scanit_representation.py"
+}

--- a/method/SCAN-IT/config/config_seqFISH_mouse_SScortex.json
+++ b/method/SCAN-IT/config/config_seqFISH_mouse_SScortex.json
@@ -1,0 +1,10 @@
+{
+    "n_genes": 3000,
+    "SomNode_k": 5,
+    "knn_n_neighbours": 5,
+    "n_h": 10,
+    "n_epoch": 2000,
+    "alpha_n_layers": 1,
+    "n_neighbours": 10, 
+    "source": "https://github.com/zcang/SCAN-IT/blob/main/examples/seqFISH-mouse-SScortex/scanit.ipynb"
+}

--- a/method/SCAN-IT/config/config_slideseq_hippocampus.json
+++ b/method/SCAN-IT/config/config_slideseq_hippocampus.json
@@ -1,0 +1,10 @@
+{
+    "n_genes": 3000,
+    "SomNode_k": 5,
+    "knn_n_neighbours": 15,
+    "n_h": 30,
+    "n_epoch": 5000,
+    "alpha_n_layers": 2,
+    "n_neighbours": 15, 
+    "source": "https://github.com/zcang/SCAN-IT/blob/main/examples/Slide-seq/scanit.ipynb"
+}

--- a/method/SCAN-IT/config/config_slideseq_mouse_cerebellum.json
+++ b/method/SCAN-IT/config/config_slideseq_mouse_cerebellum.json
@@ -1,0 +1,10 @@
+{
+    "n_genes": 3000,
+    "SomNode_k": 5,
+    "knn_n_neighbours": 5,
+    "n_h": 30,
+    "n_epoch": 2000,
+    "alpha_n_layers": 2,
+    "n_neighbours": 15, 
+    "source": "https://github.com/zcang/SCAN-IT/blob/main/examples/Slide-seq"
+}

--- a/method/SCAN-IT/config/config_slideseq_mouse_olfactory_bulb.json
+++ b/method/SCAN-IT/config/config_slideseq_mouse_olfactory_bulb.json
@@ -1,0 +1,10 @@
+{
+    "n_genes": 3000,
+    "SomNode_k": 1,
+    "knn_n_neighbours": 15,
+    "n_h": 30,
+    "n_epoch": 5000,
+    "alpha_n_layers": 2,
+    "n_neighbours": 15, 
+    "source": "https://github.com/zcang/SCAN-IT/blob/main/examples/Slide-seq/scanit.ipynb"
+}

--- a/method/SCAN-IT/method_scanit.py
+++ b/method/SCAN-IT/method_scanit.py
@@ -150,7 +150,7 @@ sc.pp.normalize_total(adata)
 # SV genes
 from somde import SomNode
 pts = adata.obsm['spatial']
-df_sp = pd.DataFrame(data=adata.X, columns=list(adata.var_names))
+df_sp = pd.DataFrame(data=adata.X.toarray(), columns=list(adata.var_names))
 som = SomNode(pts, config["SomNode_k"])
 ndf,ninfo = som.mtx(df_sp.T)
 nres = som.norm()

--- a/method/SCAN-IT/scanit.yml
+++ b/method/SCAN-IT/scanit.yml
@@ -4,13 +4,14 @@ channels:
   - anaconda
   - conda-forge
 dependencies:
+  - python=3.10.14
   - umap-learn=0.5.5
   - gcc=12.1.0
   - anndata=0.10.3
   - gudhi=3.8.0
   - matplotlib=3.8.0
-  - torchvision=0.16.0
-  - torchaudio=2.1.0
+  - torchvision=0.15.2
+  - torchaudio=0.12.1 #ytorch/noarch::pytorch-mutex-1.0-cuda; pytorch/linux-64::torchaudio-0.12.1-py310_cu116 <- 2.1.0
   - cpuonly=2.0
   - pytorch=2.1.0
   - pyg=2.4.0
@@ -23,6 +24,9 @@ dependencies:
   - pandas=2.1.4
   - networkx=2.6.3
   - leidenalg=0.10.1
+  - somoclu=1.7.6
+  - patsy=0.5.6
+  - pip
   - pip:
-      - somoclu==1.7.6
+      - somde==0.1.8     
       - "git+https://github.com/zcang/SCAN-IT.git@ebf38949eea9348cd1791f392789a8a8c0ae1e47#egg=scanit"

--- a/method/SCAN-IT/scanit_optargs.json
+++ b/method/SCAN-IT/scanit_optargs.json
@@ -1,5 +1,5 @@
 {
-    "matrix": "transform",
+    "matrix": "counts",
     "integrated_feature_selection": false,
     "image": false,
     "neighbors": false,


### PR DESCRIPTION
- Included n_genes but not n_pcs.
- Added SVGs preprocessing using the `SomNode` function according to their [example](https://github.com/zcang/SCAN-IT/blob/main/examples/Slide-seq/somde_preprocess.py).
- Added configurations based on their [example](https://github.com/zcang/SCAN-IT/blob/main/examples).
- Updated YMAL file: added `somde` for SVGs calculation. 
- It takes hours to install the Conda environment with the previous YMAL, and I still failed to install it. Not sure whether it is due to the Python/Conda version (conda 23.9.0). I manually installed each package and updated the version of Python/Torch I used.