### PR TITLE
Updated additional installation requirement

### DIFF
--- a/workflows/01_download.smk
+++ b/workflows/01_download.smk
@@ -29,7 +29,7 @@ rule all:
 
 rule download:
     output:
-        dir=directory(config["results_dir"] + "/{dataset}"),
+        dir=directory(config["DATASET_DIR"] + "/{dataset}"),
     conda:
         lambda wildcards: GIT_DIR + DATASETS[wildcards.dataset]["env"]
     params:

--- a/workflows/02_preprocessing.smk
+++ b/workflows/02_preprocessing.smk
@@ -20,7 +20,7 @@ def create_quality_control_input(wildcards):
     file_list = ["coordinates.tsv", "counts.mtx", "features.tsv", "observations.tsv"]
     all_qc_file = []
     for dataset in datasets_selected:
-        data_dir = config["dataset_dir"] +  "/" + dataset
+        data_dir = config["DATASET_DIR"] +  "/" + dataset
         if "experiment.json" in os.listdir(data_dir):
             all_qc_file += create_input(file_list, "/qc/counts.mtx", data_dir)
             all_qc_file += create_input(file_list, "/qc/features.tsv", data_dir)
@@ -53,16 +53,16 @@ rule all:
 
 rule quality_control:
     input:
-        coordinates=config["dataset_dir"] + "/{dataset}/{sample}/coordinates.tsv",
-        matrix=config["dataset_dir"] + "/{dataset}/{sample}/counts.mtx",
-        features=config["dataset_dir"] + "/{dataset}/{sample}/features.tsv",
-        observations=config["dataset_dir"] + "/{dataset}/{sample}/observations.tsv",
+        coordinates=config["DATASET_DIR"] + "/{dataset}/{sample}/coordinates.tsv",
+        matrix=config["DATASET_DIR"] + "/{dataset}/{sample}/counts.mtx",
+        features=config["DATASET_DIR"] + "/{dataset}/{sample}/features.tsv",
+        observations=config["DATASET_DIR"] + "/{dataset}/{sample}/observations.tsv",
     output:
-        dir=directory(config["dataset_dir"] + "/{dataset}/{sample}/qc"),
-        counts=config["dataset_dir"] + "/{dataset}/{sample}/qc/counts.mtx",
-        features=config["dataset_dir"] + "/{dataset}/{sample}/qc/features.tsv",
-        observations=config["dataset_dir"] + "/{dataset}/{sample}/qc/observations.tsv",
-        coordinates=config["dataset_dir"] + "/{dataset}/{sample}/qc/coordinates.tsv",
+        dir=directory(config["DATASET_DIR"] + "/{dataset}/{sample}/qc"),
+        counts=config["DATASET_DIR"] + "/{dataset}/{sample}/qc/counts.mtx",
+        features=config["DATASET_DIR"] + "/{dataset}/{sample}/qc/features.tsv",
+        observations=config["DATASET_DIR"] + "/{dataset}/{sample}/qc/observations.tsv",
+        coordinates=config["DATASET_DIR"] + "/{dataset}/{sample}/qc/coordinates.tsv",
     conda:
         GIT_DIR + "preprocessing/quality_control/qc_scanpy.yml"
     params:
@@ -74,8 +74,8 @@ rule quality_control:
           -m {input.matrix} \
           -f {input.features} \
           -o {input.observations} \
-          --min_genes {params.opt["min_genes"]}\
-          --min_cells {params.opt["min_cells"]} \
-          --min_counts {params.opt["min_counts"]} \
+          --min_genes {params.opt[min_genes]}\
+          --min_cells {params.opt[min_cells]} \
+          --min_counts {params.opt[min_counts]} \
           -d {output.dir}
         """

--- a/workflows/03_methods.smk
+++ b/workflows/03_methods.smk
@@ -3,15 +3,15 @@ import json
 from pathlib import Path
 import pandas as pd
 
-from shared.functions import get_git_directory, get_ncluster, get_sample_dirs, get_combined_domai
+from shared.functions import get_git_directory, get_ncluster, get_sample_dirs
 
 configfile: "path_config.yaml"
 configfile: "excute_config.yaml"
 
 GIT_DIR = Path(get_git_directory(config))
-DATASET_DIR = Path(config["dataset_dir"])
+DATASET_DIR = Path(config["DATASET_DIR"])
 METHODS = config.pop("methods")
-SEED = config["seed"]
+SEED = config["SEED"]
 # Scope of excution: Selected methods + selected datasets
 methods_selected = config["methods_selected"]
 datasets_selected = config["datasets_selected"]
@@ -118,7 +118,7 @@ def get_config_file(wildcards):
 # Find if the method has an additional shell scripts for installation
 def get_requirements(wildcards):
     if METHODS[wildcards.method].get("env_additional") is not None:
-        return f"{wildcards.method}_requirements.info"
+        return f".snakemake/requirements/{wildcards.method}/requirements.info"
     else:
         return []
 
@@ -128,12 +128,19 @@ rule installation_requirements:
     params:
         install_script=lambda wildcards: GIT_DIR / METHODS[wildcards.method]["env_additional"],
     output:
-        "{method}_requirements.info",
+        requirements_dir=directory(".snakemake/requirements/{method}"),
+        requirements_info=".snakemake/requirements/{method}/requirements.info",
     conda:
         lambda wildcards: str(GIT_DIR / METHODS[wildcards.method]["env"])
     shell:
         """
-        {params.install_script} && touch {output}
+        {params.install_script} &&  touch {output.requirements_info}
+        if [ $? -eq 0 ]; then
+            touch "{output.requirements_info}"
+        else
+            echo "Installation failed for {wildcards.method}" >&2
+            exit 1
+        fi
         """
 
 

--- a/workflows/04_metrics.smk
+++ b/workflows/04_metrics.smk
@@ -10,7 +10,7 @@ GIT_DIR = get_git_directory(config)
 
 # Get all the methods and metrics that's being used
 METRICS = config["metrics"]
-DATASET_DIR = config["dataset_dir"]
+DATASET_DIR = config["DATASET_DIR"]
 datasets_selected= config["datasets_selected"]
 methods_selected = config["methods_selected"]
 metrics_selected = config["metrics_selected"]

--- a/workflows/05_aggregation.smk
+++ b/workflows/05_aggregation.smk
@@ -9,7 +9,7 @@ configfile: "excute_config.yaml"
 GIT_DIR = get_git_directory(config)
 
 # Get all the methods and metrics that's being used
-DATASET_DIR = config["dataset_dir"]
+DATASET_DIR = config["DATASET_DIR"]
 datasets_selected= config["datasets_selected"]
 
 def generate_input_files(data_dir):

--- a/workflows/06_select_base_clusterings.smk
+++ b/workflows/06_select_base_clusterings.smk
@@ -9,8 +9,8 @@ configfile: "path_config.yaml"
 configfile: "excute_config.yaml"
 
 GIT_DIR = Path(get_git_directory(config))
-DATASET_DIR = Path(config["dataset_dir"])
-SEED = config["seed"]
+DATASET_DIR = Path(config["DATASET_DIR"])
+SEED = config["SEED"]
 datasets_selected = config["dataset_selected"]
 selection_metrics = config["selection_metrics"]
 

--- a/workflows/07_consensus.smk
+++ b/workflows/07_consensus.smk
@@ -9,8 +9,8 @@ configfile: "path_config.yaml"
 configfile: "excute_config.yaml"
 
 GIT_DIR = Path(get_git_directory(config))
-DATASET_DIR = Path(config["dataset_dir"])
-SEED = config["seed"]
+DATASET_DIR = Path(config["DATASET-DIR"])
+SEED = config["SEED"]
 datasets_selected = config["datasets_selected"]
 consensus_algorithms = config["consensus_algorithms"]
 n_clust_con = config["n_clust_consensus"]

--- a/workflows/07_consensus.smk
+++ b/workflows/07_consensus.smk
@@ -9,7 +9,7 @@ configfile: "path_config.yaml"
 configfile: "excute_config.yaml"
 
 GIT_DIR = Path(get_git_directory(config))
-DATASET_DIR = Path(config["DATASET-DIR"])
+DATASET_DIR = Path(config["DATASET_DIR"])
 SEED = config["SEED"]
 datasets_selected = config["datasets_selected"]
 consensus_algorithms = config["consensus_algorithms"]


### PR DESCRIPTION
- Revised additional installation requirements:

1. Fixed an issue where the {method}_requirements.info file was created even if the installation failed (due to the touch command), causing Snakemake to skip re-running the installation on subsequent runs, even if the method wasn’t properly installed.
2. To avoid jamming the main workflow folder, installation files are now stored in .snakemake/installations/ to keep the main workflow folder clean. I'm not sure if this is the best approach—are there any better solutions?

- Updated directories to ensure consistency with those in excuse_config.yaml.

Issue https://github.com/SpatialHackathon/SpaceHack2023/issues/328